### PR TITLE
Add 'TO' keyword

### DIFF
--- a/syntaxes/pseudocode.tmLanguage.json
+++ b/syntaxes/pseudocode.tmLanguage.json
@@ -45,7 +45,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.pseudocode",
-					"match": "(?i)\\b(if|else|try|catch|except|output|import|while|for|foreach|loop|return|print|input|set|extends|static|public|private|switch|case|do|end|break|continue)\\b"
+					"match": "(?i)\\b(if|else|try|catch|except|output|import|while|for|foreach|loop|return|print|input|set|extends|static|public|private|switch|case|do|end|break|continue|to)\\b"
 				},
 				{
 					"name": "keyword.operator.logical.pseudocode",


### PR DESCRIPTION
'TO' is sometimes used similarly to `range()` in Python during `for` statements.

E.g. `FOR i = 0 TO 16 DO`